### PR TITLE
UX improvements and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
-## v.Next
+## v.NEXT
 
-- Added support for locking up MTA for staking
+- General UX improvements
+- Fixed a bug where data would not load when a wallet was not connected
+- Fixed a bug where pending transactions would not show properly in the wallet on some views
+
+## v1.0.0
+
+- Initial app release
+- Added support for locking up MTA for staking, and claiming/withdrawing

--- a/src/components/core/CountUp.tsx
+++ b/src/components/core/CountUp.tsx
@@ -6,10 +6,11 @@ import { useFirstMountState } from 'react-use/lib/useFirstMountState';
 import { useIsIdle } from '../../context/UserProvider';
 import { Color } from '../../theme';
 
-interface Props extends CountUpProps {
+interface Props extends Omit<CountUpProps, 'end'> {
   container?: FC;
   highlight?: boolean;
   highlightColor?: Color;
+  end?: number;
 }
 
 const DEFAULT_DECIMALS = 2;
@@ -41,7 +42,7 @@ export const CountUp: FC<Props> = ({
   separator = ',',
   duration = DEFAULT_DURATION,
 }) => {
-    // eslint-disable-next-line no-restricted-globals
+  // eslint-disable-next-line no-restricted-globals
   const isValid = typeof end === 'number' && !isNaN(end);
   const prevEnd = useRef(isValid ? end : 0);
   const isIdle = useIsIdle();
@@ -50,7 +51,7 @@ export const CountUp: FC<Props> = ({
   const { countUp, update, pauseResume, start } = useCountUp({
     decimals,
     duration,
-    end: isValid ? end : 0,
+    end: isValid ? (end as number) : 0,
     separator,
     start: prevEnd.current,
     // ...(prefix ? { prefix } : null),

--- a/src/components/forms/TransactionForm/ConfirmPane.tsx
+++ b/src/components/forms/TransactionForm/ConfirmPane.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useCallback } from 'react';
 import { useSendTransaction } from '../../../context/TransactionsProvider';
 import { SubmitButton } from '../../core/Form';
-import { H3 } from '../../core/Typography';
 import {
   useFormId,
   useFormSubmitting,
@@ -16,12 +15,7 @@ interface Props {
   compact?: boolean;
 }
 
-export const ConfirmPane: FC<Props> = ({
-  children,
-  confirmLabel,
-  valid,
-  compact,
-}) => {
+export const ConfirmPane: FC<Props> = ({ children, confirmLabel, valid }) => {
   const sendTransaction = useSendTransaction();
   const manifest = useManifest();
   const submitting = useFormSubmitting();
@@ -39,7 +33,7 @@ export const ConfirmPane: FC<Props> = ({
   return (
     <div>
       <>
-        {compact ? null : <H3 borderTop>Confirm transaction</H3>}
+        <div>{children}</div>
         <SubmitButton
           type="button"
           onClick={handleSend}
@@ -47,7 +41,6 @@ export const ConfirmPane: FC<Props> = ({
         >
           {confirmLabel}
         </SubmitButton>
-        <div>{children}</div>
       </>
     </div>
   );

--- a/src/components/forms/TransactionForm/index.tsx
+++ b/src/components/forms/TransactionForm/index.tsx
@@ -34,7 +34,7 @@ export const TransactionForm: FC<Props> = ({
   <Container className={className} compact={compact}>
     {input ? <InputPane>{input}</InputPane> : null}
     <ConfirmPane compact={compact} confirmLabel={confirmLabel} valid={valid}>
-      {valid ? confirm : null}
+      {confirm}
     </ConfirmPane>
     {compact ? null : (
       <TransactionsPane transactionsLabel={transactionsLabel} />

--- a/src/components/pages/PageHeader.tsx
+++ b/src/components/pages/PageHeader.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import styled from 'styled-components';
 
 import { H2, H3 } from '../core/Typography';
-import { FontSize } from '../../theme';
+import { FontSize, ViewportWidth } from '../../theme';
 
 interface Props {
   icon: JSX.Element;
@@ -13,7 +13,8 @@ interface Props {
 const Icon = styled.div`
   padding: 0;
 
-  img, svg {
+  img,
+  svg {
     width: 64px;
     height: 64px;
     margin-right: 16px;
@@ -24,11 +25,24 @@ const Icon = styled.div`
   }
 `;
 
+const Content = styled.div`
+  width: 100%;
+
+  @media (min-width: ${ViewportWidth.s}) {
+    display: flex;
+    justify-content: space-between;
+  }
+`;
+
 const Container = styled.div`
   margin-bottom: 32px;
   display: flex;
   align-items: flex-start;
-  max-width: 500px;
+
+  h2,
+  h3 {
+    max-width: 500px;
+  }
 
   h2 {
     font-size: ${FontSize.xl};
@@ -38,10 +52,12 @@ const Container = styled.div`
 export const PageHeader: FC<Props> = ({ children, title, subtitle, icon }) => (
   <Container>
     <Icon>{icon}</Icon>
-    <div>
-      <H2>{title}</H2>
-      <H3>{subtitle}</H3>
+    <Content>
+      <div>
+        <H2>{title}</H2>
+        <H3>{subtitle}</H3>
+      </div>
       <div>{children}</div>
-    </div>
+    </Content>
   </Container>
 );

--- a/src/components/pages/Stake/StakeInfo.tsx
+++ b/src/components/pages/Stake/StakeInfo.tsx
@@ -10,32 +10,16 @@ import { useRewardsEarned, useStakeData } from './StakeProvider';
 import { useToken } from '../../../context/DataProvider/TokensProvider';
 import { useTotalSupply } from '../../../context/DataProvider/subscriptions';
 import { ONE_WEEK } from '../../../utils/constants';
-import { Protip } from '../../core/Protip';
-import { ExternalLink } from '../../core/ExternalLink';
+import { ViewportWidth } from '../../../theme';
 
 const ChangingCountUp = styled(CountUp)`
   color: ${({ theme }) => theme.color.blue};
-`;
-
-const SimulatedCountUp = styled(CountUp)`
-  color: ${({ theme }) => theme.color.green};
 `;
 
 const Row = styled.div`
   align-items: center;
   padding-bottom: 8px;
 `;
-
-const EarningPowerProtip: FC = () => (
-  <Row>
-    <Protip emoji="💪" title="Earning power calculation">
-      Wondering how your earning power is calculated?{' '}
-      <ExternalLink href="https://medium.com/mstable/mta-staking-v1-voting-weights-and-rewards-3a25d1d42124">
-        Read more here
-      </ExternalLink>
-    </Protip>
-  </Row>
-);
 
 const InfoRow: FC<{ tip?: string; title: string }> = ({
   children,
@@ -60,15 +44,13 @@ const InfoGroup = styled.div`
   padding-bottom: 16px;
 `;
 
-export const StakeInfo: FC = () => {
-  const { incentivisedVotingLockup, simulatedData } = useStakeData();
+const UserStake: FC = () => {
+  const { incentivisedVotingLockup } = useStakeData();
 
   const {
-    totalValue,
     userLockup,
     userStakingBalance,
     totalStaticWeight,
-    totalStakingRewards,
     userStakingReward,
     address,
   } = incentivisedVotingLockup || {};
@@ -77,41 +59,11 @@ export const StakeInfo: FC = () => {
   const totalSupply = useTotalSupply(address);
   const rewards = useRewardsEarned();
 
-  const {
-    totalStaticWeight: simTotalStaticWeight,
-    userLockup: simUserLockup,
-    userStakingBalance: simUserStakingBalance,
-    userStakingReward: simUserStakingReward,
-  } = simulatedData || {};
-
   return (
-    <>
-      <H3 borderTop>Totals</H3>
-      <InfoGroup>
-        <InfoRow
-          title="Total MTA staked"
-          tip="Total units of MTA locked in Staking"
-        >
-          {totalValue ? (
-            <CountUp end={totalValue.simple} />
-          ) : (
-            <Skeleton width={100} />
-          )}
-        </InfoRow>
-        <InfoRow
-          title="Total weekly rewards"
-          tip="Units of MTA being emitted to stakers this week"
-        >
-          {totalStakingRewards ? (
-            <CountUp end={totalStakingRewards.simple} suffix=" MTA" />
-          ) : (
-            <Skeleton width={100} />
-          )}
-        </InfoRow>
-      </InfoGroup>
+    <div>
+      <H3 borderTop>Your stake</H3>
       {userStakingBalance && userLockup && userStakingBalance.simple > 0 ? (
         <>
-          <H3 borderTop>Your Stake</H3>
           <InfoGroup>
             <InfoRow title="You staked">
               <ChangingCountUp end={userLockup.value.simple} suffix=" MTA" />{' '}
@@ -158,9 +110,8 @@ export const StakeInfo: FC = () => {
               )
             </InfoRow>
           </InfoGroup>
-          <H3 borderTop>Your Rewards</H3>
+          <H3 borderTop>Your rewards</H3>
           <InfoGroup>
-            <EarningPowerProtip />
             <InfoRow
               title="Earning Power"
               tip="Earning power is a function of amount staked and lockup time. The longer the lockup, the higher the earning power. Specifically, power = stake * sqrt(time)."
@@ -207,7 +158,7 @@ export const StakeInfo: FC = () => {
               </>
             </InfoRow>
             <InfoRow
-              title="Your Rewards APY"
+              title="Your rewards APY"
               tip="APY is highly volatile because it is based on your earning power with respect to the total earning power. As more MTA is staked, a users share is likely to go down."
             >
               {userStakingReward && userStakingReward.currentAPY ? (
@@ -235,114 +186,76 @@ export const StakeInfo: FC = () => {
             </InfoRow>
           </InfoGroup>
         </>
-      ) : simulatedData && simUserLockup && simUserStakingBalance ? (
-        <>
-          <H3 borderTop>Your Stake</H3>
-          <InfoGroup>
-            <InfoRow title="You will stake">
-              <SimulatedCountUp
-                end={simUserLockup.value.simple}
-                suffix=" MTA"
-              />{' '}
-              for {(simUserLockup.length / ONE_WEEK.toNumber()).toFixed(1)}{' '}
-              weeks
-            </InfoRow>
-            <InfoRow
-              title="Voting Power"
-              tip="Voting power (AKA vMTA balance) decays linearly over time - vMTA balance is used as your voting weight in community proposals"
-            >
-              You <b>would</b> start with{' '}
-              {simUserLockup.bias.simple &&
-              totalSupply &&
-              totalSupply.simple > 0 ? (
-                <SimulatedCountUp
-                  end={
-                    (simUserLockup.bias.simple /
-                      (totalSupply.simple + simUserLockup.bias.simple)) *
-                    100
-                  }
-                  decimals={6}
-                  suffix=" %"
-                />
-              ) : (
-                <Skeleton width={100} />
-              )}{' '}
-              of the voting power (
-              <SimulatedCountUp
-                end={simUserLockup.bias.simple}
-                suffix=" vMTA"
-                decimals={4}
-              />{' '}
-              out of{' '}
-              {totalSupply ? (
-                <SimulatedCountUp
-                  end={totalSupply.simple + simUserLockup.bias.simple}
-                  suffix=" vMTA"
-                  decimals={4}
-                />
-              ) : (
-                <Skeleton width={100} />
-              )}
-              )
-            </InfoRow>
-          </InfoGroup>
-          <H3 borderTop>Your Rewards</H3>
-          <InfoGroup>
-            <EarningPowerProtip />
-            <InfoRow
-              title="Earning Power"
-              tip="Earning power is a function of amount staked and lockup time. The longer the lockup, the higher the earning power. Specifically, power = stake * sqrt(time)."
-            >
-              You <b>would</b> start with{' '}
-              {simTotalStaticWeight && simTotalStaticWeight.simple > 0 ? (
-                <SimulatedCountUp
-                  end={
-                    (simUserStakingBalance.simple /
-                      simTotalStaticWeight.simple) *
-                    100
-                  }
-                  suffix=" %"
-                  decimals={6}
-                />
-              ) : (
-                <Skeleton width={100} />
-              )}{' '}
-              of the earning power (
-              <SimulatedCountUp
-                end={simUserStakingBalance.simple}
-                suffix=" pMTA"
-                decimals={4}
-              />{' '}
-              out of{' '}
-              {simTotalStaticWeight ? (
-                <SimulatedCountUp
-                  end={simTotalStaticWeight.simple}
-                  suffix=" pMTA"
-                  decimals={4}
-                />
-              ) : (
-                <Skeleton width={100} />
-              )}
-              )
-            </InfoRow>
-            <InfoRow
-              title="Your Rewards APY"
-              tip="APY is highly volatile because it is based on your earning power with respect to the total earning power. As more MTA is staked, a users share is likely to go down."
-            >
-              {simUserStakingReward ? (
-                <SimulatedCountUp
-                  end={simUserStakingReward.currentAPY || 0}
-                  suffix=" %"
-                />
-              ) : (
-                <Skeleton width={100} />
-              )}
-            </InfoRow>
-          </InfoGroup>
-        </>
       ) : (
-        <Skeleton height={300} />
+        <InfoGroup>
+          <InfoRow title="No stake">
+            <p>
+              You have not yet staked; you can stake MTA with the stake form
+              below.
+            </p>
+          </InfoRow>
+        </InfoGroup>
       )}
-    </>
+    </div>
+  );
+};
+
+const Totals: FC = () => {
+  const { incentivisedVotingLockup } = useStakeData();
+  const { totalValue, totalStakingRewards } = incentivisedVotingLockup || {};
+
+  return (
+    <InfoGroup>
+      <H3 borderTop>Totals</H3>
+      <InfoRow
+        title="Total MTA staked"
+        tip="Total units of MTA locked in Staking"
+      >
+        {totalValue ? (
+          <CountUp end={totalValue.simple} />
+        ) : (
+          <Skeleton width={100} />
+        )}
+      </InfoRow>
+      <InfoRow
+        title="Total weekly rewards"
+        tip="Units of MTA being emitted to stakers this week"
+      >
+        {totalStakingRewards ? (
+          <CountUp end={totalStakingRewards.simple} suffix=" MTA" />
+        ) : (
+          <Skeleton width={100} />
+        )}
+      </InfoRow>
+    </InfoGroup>
+  );
+};
+
+const Container = styled.div`
+  > * {
+    width: 100%;
+    margin-bottom: 16px;
+  }
+
+  @media (min-width: ${ViewportWidth.s}) {
+    display: flex;
+    justify-content: space-between;
+
+    > :first-child {
+      margin-right: 8px;
+    }
+
+    > :last-child {
+      margin-left: 8px;
+    }
+  }
+`;
+
+export const StakeInfo: FC = () => {
+  return (
+    <Container>
+      <UserStake />
+      <Totals />
+    </Container>
   );
 };

--- a/src/components/pages/Stake/createLock/CreateLockConfirm.tsx
+++ b/src/components/pages/Stake/createLock/CreateLockConfirm.tsx
@@ -1,23 +1,208 @@
 import React, { FC } from 'react';
-import { useStakeState } from '../StakeProvider';
-import { TransactionType } from '../types';
+import styled from 'styled-components';
+import Skeleton from 'react-loading-skeleton/lib';
+
+import { useTotalSupply } from '../../../../context/DataProvider/subscriptions';
+import { ONE_WEEK } from '../../../../utils/constants';
 import { CountUp } from '../../../core/CountUp';
+import { H3, H4 } from '../../../core/Typography';
+import { Tooltip } from '../../../core/ReactTooltip';
+import { useStakeState } from '../StakeProvider';
+import { ViewportWidth } from '../../../../theme';
 
-export const CreateLockConfirm: FC<{}> = () => {
+const SimulatedCountUp = styled(CountUp)`
+  color: ${({ theme }) => theme.color.green};
+`;
+
+const Row = styled.div`
+  align-items: center;
+  padding-bottom: 8px;
+`;
+
+const InfoRow: FC<{ tip?: string; title: string }> = ({
+  children,
+  title,
+  tip,
+}) => {
+  return (
+    <Row>
+      {tip ? (
+        <Tooltip tip={tip}>
+          <H4>{title}</H4>
+        </Tooltip>
+      ) : (
+        <H4>{title}</H4>
+      )}
+      <div>{children}</div>
+    </Row>
+  );
+};
+
+const InfoGroup = styled.div`
+  padding-bottom: 16px;
+`;
+
+const Container = styled.div<{ valid: boolean }>`
+  margin-top: 16px;
+  opacity: ${({ valid }) => (valid ? 1 : 0.5)};
+
+  > * {
+    width: 100%;
+    margin-bottom: 16px;
+  }
+
+  @media (min-width: ${ViewportWidth.s}) {
+    display: flex;
+    justify-content: space-between;
+
+    > :first-child {
+      margin-right: 8px;
+    }
+
+    > :last-child {
+      margin-left: 8px;
+    }
+  }
+`;
+
+export const CreateLockConfirm: FC = () => {
   const {
-    data: { metaToken },
+    data: { incentivisedVotingLockup, simulatedData },
     valid,
-    transactionType,
-    lockupAmount: { amount },
-    lockupPeriod: { formValue },
   } = useStakeState();
-  const txCheck = transactionType === TransactionType.CreateLock;
 
-  return amount && valid && txCheck && metaToken ? (
-    <div>
-      You are staking{' '}
-      <CountUp end={amount?.simpleRounded} suffix={` ${metaToken.symbol}`} />{' '}
-      for {formValue} days.
-    </div>
-  ) : null;
+  const { address } = incentivisedVotingLockup || {};
+
+  const totalSupply = useTotalSupply(address);
+
+  const {
+    totalStaticWeight: simTotalStaticWeight,
+    userLockup: simUserLockup,
+    userStakingBalance: simUserStakingBalance,
+    userStakingReward: simUserStakingReward,
+  } = simulatedData || {};
+
+  return (
+    <Container valid={valid}>
+      <div>
+        <H3 borderTop>Your stake</H3>
+        <InfoGroup>
+          <InfoRow title="You will stake">
+            <SimulatedCountUp
+              end={
+                simUserLockup && simUserLockup.value.simple > 0
+                  ? simUserLockup.value.simple
+                  : undefined
+              }
+              suffix=" MTA"
+            />{' '}
+            for{' '}
+            {simUserLockup
+              ? (simUserLockup.length / ONE_WEEK.toNumber()).toFixed(1)
+              : '-'}{' '}
+            weeks
+          </InfoRow>
+          <InfoRow
+            title="Voting Power"
+            tip="Voting power (AKA vMTA balance) decays linearly over time - vMTA balance is used as your voting weight in community proposals"
+          >
+            You would start with{' '}
+            {simUserLockup?.bias.simple &&
+            simUserLockup.bias.simple > 0 &&
+            totalSupply &&
+            totalSupply.simple > 0 ? (
+              <SimulatedCountUp
+                end={
+                  (simUserLockup.bias.simple /
+                    (totalSupply.simple + simUserLockup.bias.simple)) *
+                  100
+                }
+                decimals={6}
+                suffix=" %"
+              />
+            ) : (
+              '-'
+            )}{' '}
+            of the voting power (
+            <SimulatedCountUp
+              end={simUserLockup?.bias.simple}
+              suffix=" vMTA"
+              decimals={4}
+            />{' '}
+            out of{' '}
+            {totalSupply ? (
+              <SimulatedCountUp
+                end={
+                  simUserLockup?.bias
+                    ? totalSupply.simple + simUserLockup.bias.simple
+                    : undefined
+                }
+                suffix=" vMTA"
+                decimals={4}
+              />
+            ) : (
+              <Skeleton width={100} />
+            )}
+            )
+          </InfoRow>
+        </InfoGroup>
+      </div>
+      <div>
+        <H3 borderTop>Your rewards</H3>
+        <InfoGroup>
+          <InfoRow
+            title="Earning Power"
+            tip="Earning power is a function of amount staked and lockup time. The longer the lockup, the higher the earning power. Specifically, power = stake * sqrt(time)."
+          >
+            You would start with{' '}
+            {simTotalStaticWeight &&
+            simUserStakingBalance &&
+            simTotalStaticWeight.simple > 0 &&
+            simUserStakingBalance.simple > 0 ? (
+              <SimulatedCountUp
+                end={
+                  (simUserStakingBalance.simple / simTotalStaticWeight.simple) *
+                  100
+                }
+                suffix=" %"
+                decimals={6}
+              />
+            ) : (
+              '-'
+            )}{' '}
+            of the earning power (
+            <SimulatedCountUp
+              end={simUserStakingBalance?.simple}
+              suffix=" pMTA"
+              decimals={4}
+            />{' '}
+            out of{' '}
+            {simTotalStaticWeight ? (
+              <SimulatedCountUp
+                end={simTotalStaticWeight.simple}
+                suffix=" pMTA"
+                decimals={4}
+              />
+            ) : (
+              <Skeleton width={100} />
+            )}
+            )
+          </InfoRow>
+          <InfoRow
+            title="Your rewards APY"
+            tip="APY is highly volatile because it is based on your earning power with respect to the total earning power. As more MTA is staked, a users share is likely to go down."
+          >
+            {simUserStakingReward ? (
+              <SimulatedCountUp
+                end={simUserStakingReward.currentAPY || 0}
+                suffix=" %"
+              />
+            ) : (
+              '-'
+            )}
+          </InfoRow>
+        </InfoGroup>
+      </div>
+    </Container>
+  );
 };

--- a/src/components/pages/Stake/index.tsx
+++ b/src/components/pages/Stake/index.tsx
@@ -1,9 +1,17 @@
 import React, { FC } from 'react';
+import styled from 'styled-components';
+
 import { StakeForms } from './StakeForms';
 import { StakeProvider } from './StakeProvider';
 import { PageHeader } from '../PageHeader';
 import { StakeInfo } from './StakeInfo';
 import { ReactComponent as StakeIcon } from '../../icons/circle/lock.svg';
+import { Protip } from '../../core/Protip';
+import { ExternalLink } from '../../core/ExternalLink';
+
+const StyledProtip = styled(Protip)`
+  font-size: 12px;
+`;
 
 export const StakeTabs: FC = () => {
   return (
@@ -12,7 +20,14 @@ export const StakeTabs: FC = () => {
         icon={<StakeIcon />}
         title="Stake"
         subtitle="Stake your MTA to participate in mStable protocol governance"
-      />
+      >
+        <StyledProtip emoji="💪" title="Earning power calculation">
+          Wondering how your earning power is calculated?{' '}
+          <ExternalLink href="https://medium.com/mstable/mta-staking-v1-voting-weights-and-rewards-3a25d1d42124">
+            Read more here
+          </ExternalLink>
+        </StyledProtip>
+      </PageHeader>
       <StakeInfo />
       <StakeForms />
     </StakeProvider>

--- a/src/components/pages/Stake/reducer.ts
+++ b/src/components/pages/Stake/reducer.ts
@@ -15,20 +15,6 @@ import { getShareAndAPY } from './helpers';
 const reduce: Reducer<State, Action> = (state, action) => {
   switch (action.type) {
     case Actions.Data:
-      if (state.lockupPeriod.formValue === 0) {
-        const min = state.data.incentivisedVotingLockup?.lockTimes.min;
-        if (min) {
-          const derived = min + 7 * 26;
-          const unlockTime = Math.floor(
-            addDays(Date.now(), derived).getTime() / 1000,
-          );
-          return {
-            ...state,
-            data: action.payload,
-            lockupPeriod: { unlockTime, formValue: derived },
-          };
-        }
-      }
       return {
         ...state,
         data: action.payload,
@@ -81,8 +67,8 @@ const reduce: Reducer<State, Action> = (state, action) => {
             data.metaToken?.balance.decimals,
             false,
           ),
-          touched: true,
         },
+        touched: true,
       };
     }
 

--- a/src/components/pages/Stake/types.ts
+++ b/src/components/pages/Stake/types.ts
@@ -51,8 +51,8 @@ export enum Reasons {
   FetchingData = 'Failed to fetch data',
   AmountMustBeGreaterThanZero = 'Amount must be greater than zero',
   AmountMustBeSet = 'Amount must be set',
-  PeriodMustBeSet = 'Lock up period must be set',
-  PeriodMustBeLongerThanOneWeek = 'Lock up period must be longer than one week',
+  PeriodMustBeSet = 'Lockup period must be set',
+  PeriodMustBeAtLeastSixDays = 'Lockup period must be at least six days',
   AmountMustNotExceedBalance = 'Amount must not exceed balance',
   AmountExceedsApprovedAmount = 'Amount exceeds approved amount',
 }

--- a/src/components/pages/Stake/validation.ts
+++ b/src/components/pages/Stake/validation.ts
@@ -2,7 +2,7 @@ import { Reasons, State } from './types';
 
 const validateLock = ({
   lockupAmount: { amount },
-  lockupPeriod: { unlockTime, formValue },
+  lockupPeriod: { unlockTime },
   data: { metaToken, incentivisedVotingLockup },
 }: State): [false, Reasons] | [true] => {
   if (
@@ -25,11 +25,10 @@ const validateLock = ({
     return [false, Reasons.PeriodMustBeSet];
   }
 
-  // TODO should validate unlockTime vs now
-  //  or vs the lockTime of the existing lockup (for increasing the time)
-  if (formValue < 7) {
-    return [false, Reasons.PeriodMustBeLongerThanOneWeek];
-  }
+  // TODO should validate the existing lockup (for increasing the time)
+  // if (formValue < 6) {
+  //   return [false, Reasons.PeriodMustBeAtLeastSixDays];
+  // }
 
   if (amount.exact.gt(metaToken.balance.exact)) {
     return [false, Reasons.AmountMustNotExceedBalance];

--- a/src/components/wallet/Transactions.tsx
+++ b/src/components/wallet/Transactions.tsx
@@ -9,8 +9,6 @@ import { ActivitySpinner } from '../core/ActivitySpinner';
 import { EtherscanLink } from '../core/EtherscanLink';
 import { List, ListItem } from '../core/List';
 import { P } from '../core/Typography';
-import { State } from '../pages/Stake/types';
-import { useStakeState } from '../pages/Stake/StakeProvider';
 
 const PendingTxContainer = styled.div<{ inverted?: boolean }>`
   display: flex;
@@ -44,26 +42,13 @@ const getStatusLabel = (status: TransactionStatus): string =>
     ? 'Error'
     : 'Pending';
 
-const getPendingTxDescription = (
-  tx: Transaction,
-  stakingData?: State,
-): JSX.Element => {
+const getPendingTxDescription = (tx: Transaction): JSX.Element => {
   switch (tx.fn) {
     case 'claimReward': {
       return <> You {tx.status ? 'claimed' : 'are claiming'} MTA rewards</>;
     }
     case 'createLock': {
-      return (
-        <>
-          {' '}
-          You {tx.status ? 'staked' : 'are staking'}{' '}
-          {stakingData?.lockupAmount.amount?.simple} MTA for{' '}
-          {stakingData
-            ? (stakingData.lockupPeriod.formValue / 7).toFixed(1)
-            : null}{' '}
-          weeks{' '}
-        </>
-      );
+      return <> You {tx.status ? 'staked' : 'are staking'} MTA</>;
     }
     case 'withdraw': {
       return (
@@ -103,12 +88,7 @@ const PendingTx: FC<{
   tx: Transaction;
   inverted: boolean;
 }> = ({ tx, inverted }) => {
-  const stakingData = useStakeState();
-
-  const description = useMemo(() => getPendingTxDescription(tx, stakingData), [
-    tx,
-    stakingData,
-  ]);
+  const description = useMemo(() => getPendingTxDescription(tx), [tx]);
 
   return (
     <PendingTxContainer inverted={inverted}>

--- a/src/context/DataProvider/subscriptions.ts
+++ b/src/context/DataProvider/subscriptions.ts
@@ -61,7 +61,7 @@ export const useUserLockupsSubscription = (
   account?: string,
 ): UserLockupsQueryResult => {
   return useBlockPollingSubscription(useUserLockupsLazyQuery, {
-    variables: { account: account as string },
+    variables: { account: account as string, hasAccount: !!account },
   });
 };
 

--- a/src/context/DataProvider/transformRawData.ts
+++ b/src/context/DataProvider/transformRawData.ts
@@ -57,7 +57,9 @@ const transformUserStakingBalance = (
 
 export const transformRawData = ({
   tokens,
-  incentivisedVotingLockups: [incentivisedVotingLockupData],
+  incentivisedVotingLockups: [
+    incentivisedVotingLockupData,
+  ] = ([] as unknown) as RawData['incentivisedVotingLockups'],
 }: RawData): DataState => {
   if (!incentivisedVotingLockupData) {
     return { tokens };
@@ -76,13 +78,13 @@ export const transformRawData = ({
     rewardRate,
     rewardsDistributor,
     rewardsToken,
-    stakingBalances: [rawUserStakingBalance],
-    stakingRewards: [rawUserStakingReward],
+    stakingBalances: [rawUserStakingBalance] = [],
+    stakingRewards: [rawUserStakingReward] = [],
     stakingToken,
     totalStakingRewards,
     totalStaticWeight,
     totalValue,
-    userLockups: [rawUserLockup],
+    userLockups: [rawUserLockup] = [],
   } = incentivisedVotingLockupData;
 
   const userLockup = transformUserLockup(rawUserLockup);

--- a/src/graphql/mstable.tsx
+++ b/src/graphql/mstable.tsx
@@ -1667,6 +1667,7 @@ export type TokenQuery = { token?: Maybe<TokenDetailsFragment> };
 
 export type UserLockupsQueryVariables = {
   account?: Maybe<Scalars['Bytes']>;
+  hasAccount: Scalars['Boolean'];
 };
 
 
@@ -1784,7 +1785,7 @@ export type TokenQueryHookResult = ReturnType<typeof useTokenQuery>;
 export type TokenLazyQueryHookResult = ReturnType<typeof useTokenLazyQuery>;
 export type TokenQueryResult = ApolloReactCommon.QueryResult<TokenQuery, TokenQueryVariables>;
 export const UserLockupsDocument = gql`
-    query UserLockups($account: Bytes) @api(name: mstable) {
+    query UserLockups($account: Bytes, $hasAccount: Boolean!) @api(name: mstable) {
   incentivisedVotingLockups {
     address: id
     periodFinish
@@ -1809,15 +1810,15 @@ export const UserLockupsDocument = gql`
       id
       fundManagers
     }
-    stakingRewards(where: {account: $account}, first: 1) {
+    stakingRewards(where: {account: $account}, first: 1) @include(if: $hasAccount) {
       amount
       amountPerTokenPaid
       rewardsPaid
     }
-    stakingBalances(where: {account: $account}, first: 1) {
+    stakingBalances(where: {account: $account}, first: 1) @include(if: $hasAccount) {
       amount
     }
-    userLockups(where: {account: $account}, first: 1) {
+    userLockups(where: {account: $account}, first: 1) @include(if: $hasAccount) {
       value
       lockTime
       ts
@@ -1841,6 +1842,7 @@ export const UserLockupsDocument = gql`
  * const { data, loading, error } = useUserLockupsQuery({
  *   variables: {
  *      account: // value for 'account'
+ *      hasAccount: // value for 'hasAccount'
  *   },
  * });
  */

--- a/src/graphql/mstable/query.graphql
+++ b/src/graphql/mstable/query.graphql
@@ -18,7 +18,7 @@ query Token($id: ID!) @api(name: mstable) {
   }
 }
 
-query UserLockups($account: Bytes) @api(name: mstable) {
+query UserLockups($account: Bytes, $hasAccount: Boolean!) @api(name: mstable) {
   incentivisedVotingLockups {
     address: id
     periodFinish
@@ -43,15 +43,18 @@ query UserLockups($account: Bytes) @api(name: mstable) {
       id
       fundManagers
     }
-    stakingRewards(where: { account: $account }, first: 1) {
+    stakingRewards(where: { account: $account }, first: 1)
+      @include(if: $hasAccount) {
       amount
       amountPerTokenPaid
       rewardsPaid
     }
-    stakingBalances(where: { account: $account }, first: 1) {
+    stakingBalances(where: { account: $account }, first: 1)
+      @include(if: $hasAccount) {
       amount
     }
-    userLockups(where: { account: $account }, first: 1) {
+    userLockups(where: { account: $account }, first: 1)
+      @include(if: $hasAccount) {
       value
       lockTime
       ts

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -3,6 +3,7 @@
 
 import { useMemo } from 'react';
 
+import formatDuration from 'date-fns/formatDuration';
 import { Erc20Detailed } from '../typechain/Erc20Detailed';
 import { Erc20DetailedFactory } from '../typechain/Erc20DetailedFactory';
 import { useSignerContext } from '../context/SignerProvider';
@@ -20,4 +21,15 @@ export const useErc20Contract = (
       signer && address ? Erc20DetailedFactory.connect(address, signer) : null,
     [address, signer],
   );
+};
+
+export const useFormatDays = (days: number): string => {
+  return useMemo<string>(() => {
+    const weeks = Math.floor(days / 7);
+    const remainderDays = Math.floor(days - weeks * 7);
+    return formatDuration(
+      { weeks, days: remainderDays },
+      { format: ['weeks', 'days'], zero: false },
+    );
+  }, [days]);
 };


### PR DESCRIPTION
**General UX improvements**

- Do not derive a value for the lockup time when the min value is provided, because it affects the form validity in unexpected ways; the user should provide a value
- Move information about the stake position the user is creating into the tx confirmation pane, to make it clearer that this is different from a created stake position, and so that the form is placed above this content for ease of use
- Remove `PeriodMustBeLongerThanOneWeek` validation (not necessary yet)
- Gray out the simulated stake when the form is not valid, and use '-' to denote values that cannot be calculated until the values are provided by the user
- Move the calculation protip to the page header
- Use the correct input component for the amount, and add a balance label
- Split the totals/your stake info when the viewport is large enough

**Bug fixes**

- Fixed a bug where data would not load when a wallet was not connected
- Fixed a bug where pending transactions would not show properly in the wallet on some views


---


**Disconnected**

<img width="1162" alt="Screenshot 2020-09-25 at 20 37 23" src="https://user-images.githubusercontent.com/5450382/94308813-034c3480-ff6f-11ea-9134-65748debd4ab.png">


**Notifications for txs now have the right text**

<img width="693" alt="Screenshot 2020-09-25 at 20 37 44" src="https://user-images.githubusercontent.com/5450382/94308859-1101ba00-ff6f-11ea-93a4-edbf1c84b77f.png">


**Validation**

<img width="1107" alt="Screenshot 2020-09-25 at 20 38 51" src="https://user-images.githubusercontent.com/5450382/94308964-3f7f9500-ff6f-11ea-91c8-a46239aca511.png">


**Good to go**

<img width="1128" alt="Screenshot 2020-09-25 at 20 39 05" src="https://user-images.githubusercontent.com/5450382/94308985-460e0c80-ff6f-11ea-8cec-001b462e5bcf.png">


**Tx sent**

<img width="568" alt="Screenshot 2020-09-25 at 20 39 28" src="https://user-images.githubusercontent.com/5450382/94309002-4dcdb100-ff6f-11ea-8f40-ceca69358987.png">


**Staked**

<img width="1901" alt="Screenshot 2020-09-25 at 20 19 12" src="https://user-images.githubusercontent.com/5450382/94308391-5e315c00-ff6e-11ea-9dcd-9c51fc9bc466.png">


**Notifications**

<img width="509" alt="Screenshot 2020-09-25 at 20 40 26" src="https://user-images.githubusercontent.com/5450382/94309052-5cb46380-ff6f-11ea-89f9-68dd5abac56c.png">
