### PR TITLE
Adds a default lockup time of half a year or max

### DIFF
--- a/src/components/pages/Stake/createLock/CreateLockConfirm.tsx
+++ b/src/components/pages/Stake/createLock/CreateLockConfirm.tsx
@@ -44,7 +44,7 @@ const InfoGroup = styled.div`
 
 const Container = styled.div<{ valid: boolean }>`
   margin-top: 16px;
-  opacity: ${({ valid }) => (valid ? 1 : 0.5)};
+  /* opacity: ${({ valid }) => (valid ? 1 : 0.5)}; */
 
   > * {
     width: 100%;

--- a/src/components/pages/Stake/reducer.ts
+++ b/src/components/pages/Stake/reducer.ts
@@ -15,6 +15,22 @@ import { getShareAndAPY } from './helpers';
 const reduce: Reducer<State, Action> = (state, action) => {
   switch (action.type) {
     case Actions.Data:
+      if (state.lockupPeriod.formValue === 0) {
+        const min = state.data.incentivisedVotingLockup?.lockTimes.min;
+        const max = state.data.incentivisedVotingLockup?.lockTimes.max;
+        if (min && max) {
+          const derived = min + 7 * 26;
+          const halfyear = Math.floor(
+            addDays(Date.now(), derived).getTime() / 1000,
+          );
+          const unlockTime = halfyear > max ? max : halfyear;
+          return {
+            ...state,
+            data: action.payload,
+            lockupPeriod: { unlockTime, formValue: derived },
+          };
+        }
+      }
       return {
         ...state,
         data: action.payload,


### PR DESCRIPTION
 - Defaults lockup length to half a year
 - Removes the shade on the invalid lockup form to allow users to view the multiplier data