### PR TITLE
Fixed logic for `Withdraw/Exit` modal

### DIFF
--- a/src/components/pages/Stake/exit/Exit.tsx
+++ b/src/components/pages/Stake/exit/Exit.tsx
@@ -27,7 +27,8 @@ const ExitForm: FC = () => {
   const setFormManifest = useSetFormManifest();
   const contract = useStakeContract();
   const canUnlock =
-    (incentivisedVotingLockup?.userLockup?.lockTime as number) > Date.now();
+    Date.now() >=
+    (incentivisedVotingLockup?.userLockup?.lockTime as number) * 1000;
   const balance = incentivisedVotingLockup?.userStakingBalance;
 
   useEffect(() => {


### PR DESCRIPTION
- updated logic for `canUnlock` variable
- `lockTime` on `incentivisedVotingLockup` was expressed in seconds while `Date.now()` is expressed in milis so had to accomodate for that