### PR TITLE
Fix ordering by LOCK START / UNLOCK TIME on Stats page

### DIFF
--- a/src/components/pages/Stats/StatsDataProvider.tsx
+++ b/src/components/pages/Stats/StatsDataProvider.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, FC, useContext, useMemo } from 'react';
 
-import { formatUnix, nowUnix } from '../../../utils/time';
+import { nowUnix } from '../../../utils/time';
 import { useAllUserLockupsQuery } from '../../../graphql/mstable';
 import { RawData, UserLockupDatum, UserLockupSimple } from './types';
 import { useIncentivisedVotingLockupAtBlock } from './IncentivisedVotingLockupAtBlockProvider';
@@ -94,9 +94,9 @@ export const StatsDataProvider: FC = ({ children }) => {
 
           return {
             account,
-            lockStart: formatUnix(ts),
+            lockStart: ts,
             mtaLocked: value.toFixed(2),
-            unlockTime: formatUnix(lockTime),
+            unlockTime: lockTime,
             vMTA: vMTA.toFixed(2),
             votingPowerPercentage: votingPowerSimple.toFixed(3).concat('%'),
             votingPowerSimple,

--- a/src/components/pages/Stats/columns.tsx
+++ b/src/components/pages/Stats/columns.tsx
@@ -2,6 +2,8 @@ import { UseTableOptions } from 'react-table';
 
 import { UserLockupDatum } from './types';
 
+import { formatUnix } from '../../../utils/time';
+
 export const COLUMNS: UseTableOptions<UserLockupDatum>['columns'] = [
   {
     Header: 'Account',
@@ -23,9 +25,11 @@ export const COLUMNS: UseTableOptions<UserLockupDatum>['columns'] = [
   {
     Header: 'Lock Start',
     accessor: 'lockStart',
+	Cell: ({ value }) => formatUnix(value)
   },
   {
     Header: 'Unlock Time',
     accessor: 'unlockTime',
+	Cell: ({ value }) => formatUnix(value)
   },
 ];

--- a/src/components/pages/Stats/types.ts
+++ b/src/components/pages/Stats/types.ts
@@ -16,9 +16,9 @@ export interface UserLockupSimple {
 
 export interface UserLockupDatum {
   account: string;
-  lockStart: string;
+  lockStart: number;
   mtaLocked: string;
-  unlockTime: string;
+  unlockTime: number;
   vMTA: string;
   votingPowerPercentage: string;
   votingPowerSimple: number;


### PR DESCRIPTION
Hi guys,

If you go to the [Stats](https://governance.mstable.org/#/stats) page and try to order by LOCK START / UNLOCK TIME, you'll realise that the ordering doesn't work.
The problem is that the date is converted to string (DD-MM-YYY) and ordered according to it.

My fix is to pass the original number and use the [Cell](https://react-table.tanstack.com/docs/api/useTable) option to format the column value.
It's nice to see that in the last few days more than $1m worth of MTA was locked in. 🚀

Here are the screenshots of the bug and the fixed versions:

Cheers,
Tamas

<img width="1792" alt="Screenshot 2021-05-03 at 16 37 56" src="https://user-images.githubusercontent.com/1397179/116890592-16726180-ac2e-11eb-889c-8e3d1f834a0b.png">
<img width="1792" alt="Screenshot 2021-05-03 at 16 38 20" src="https://user-images.githubusercontent.com/1397179/116890606-196d5200-ac2e-11eb-8426-9182330d6755.png">
